### PR TITLE
Fixed font color for textarea

### DIFF
--- a/src/content/UserPage/user-page.scss
+++ b/src/content/UserPage/user-page.scss
@@ -4,7 +4,7 @@
 $textarea-color: $carbon--white-0;
 $textarea-font-color: $carbon--cool-gray-50;
 $textarea-color-second: $carbon--cool-gray-10;
-$textarea-font-color-second: $carbon--cool-gray-10;
+$textarea-font-color-second: $carbon--black-100;
 $review-button-color: $carbon--cool-gray-50;
 $review-font-color: $carbon--cool-gray-10;
 $clean-review-button-color: $carbon--white-0;


### PR DESCRIPTION
<!-- Enter an issue number immediately after the pound sign below, if applicable  -->
Fixes #25 

### Overview 
The textarea font-color has been changed to `$carbon--black-100` for visibility. Tested on Edge, Chrome, and Firefox.

![image](https://user-images.githubusercontent.com/58940073/92617905-6a869b00-f285-11ea-9773-b686e3192a9d.png)

